### PR TITLE
Added employee and animal counts on location cards

### DIFF
--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -107,7 +107,7 @@ export const Animal = ({ animal, syncAnimals,
 
                             <h6>Owners</h6>
                             <span className="small">
-                                Owned by 
+                                Owned by
                                 {
                                     currentAnimal?.animalOwners?.map(owner => {
                                         const foundAnimalOwners = users.filter(user => {
@@ -121,40 +121,40 @@ export const Animal = ({ animal, syncAnimals,
                                     })
                                 }
                             </span>
-                                {
-                                    myOwners.length < 2
-                                        ? <select defaultValue=""
-                                            name="owner"
-                                            className="form-control small"
-                                            onChange={() => { }} >
-                                            <option value="">
-                                                Select {myOwners.length === 1 ? "another" : "an"} owner
-                                            </option>
-                                            {
-                                                allOwners.map(o => <option key={o.id} value={o.id}>{o.name}</option>)
-                                            }
-                                        </select>
-                                        : null
-                                }
+                            {
+                                myOwners.length < 2
+                                    ? <select defaultValue=""
+                                        name="owner"
+                                        className="form-control small"
+                                        onChange={() => { }} >
+                                        <option value="">
+                                            Select {myOwners.length === 1 ? "another" : "an"} owner
+                                        </option>
+                                        {
+                                            allOwners.map(o => <option key={o.id} value={o.id}>{o.name}</option>)
+                                        }
+                                    </select>
+                                    : null
+                            }
 
 
-                                {
-                                    detailsOpen && "treatments" in currentAnimal
-                                        ? <div className="small">
-                                            <h6>Treatment History</h6>
-                                            {
-                                                currentAnimal.treatments.map(t => (
-                                                    <div key={t.id}>
-                                                        <p style={{ fontWeight: "bolder", color: "grey" }}>
-                                                            {new Date(t.timestamp).toLocaleString("en-US")}
-                                                        </p>
-                                                        <p>{t.description}</p>
-                                                    </div>
-                                                ))
-                                            }
-                                        </div>
-                                        : ""
-                                }
+                            {
+                                detailsOpen && "treatments" in currentAnimal
+                                    ? <div className="small">
+                                        <h6>Treatment History</h6>
+                                        {
+                                            currentAnimal.treatments.map(t => (
+                                                <div key={t.id}>
+                                                    <p style={{ fontWeight: "bolder", color: "grey" }}>
+                                                        {new Date(t.timestamp).toLocaleString("en-US")}
+                                                    </p>
+                                                    <p>{t.description}</p>
+                                                </div>
+                                            ))
+                                        }
+                                    </div>
+                                    : ""
+                            }
                         </section>
 
                         {

--- a/src/components/employees/Employee.js
+++ b/src/components/employees/Employee.js
@@ -55,19 +55,25 @@ export default ({ employee }) => {
                     employeeId
                         ? <>
                             <section>
-                                Caring for 0 animals
+                                Caring for {resource.animals?.length} animals
                             </section>
                             <section>
-                                Working at unknown location
+                            {/* Working at {
+                                resource.locations.map(
+                                    (location) => {
+                                        return locations.location.name
+                                    }
+                                )
+                            } */}
                             </section>
                         </>
                         : ""
                 }
 
-                
+
                 {
                     isEmployee
-                        ? <button className="btn--fireEmployee" onClick={() => {}}>Fire</button>
+                        ? <button className="btn--fireEmployee" onClick={() => { }}>Fire</button>
                         : ""
                 }
 

--- a/src/components/locations/Location.js
+++ b/src/components/locations/Location.js
@@ -4,7 +4,7 @@ import locationImage from "./location.png"
 import "./Location.css"
 
 
-export default ({location}) => {
+export default ({ location }) => {
     return (
         <article className="card location" style={{ width: `18rem` }}>
             <section className="card-body">
@@ -20,10 +20,10 @@ export default ({location}) => {
                 </h5>
             </section>
             <section>
-                Total animals
+                Total animals: {location?.animals.length}
             </section>
             <section>
-                Total locations
+                Total Employees: {location?.employeeLocations.length}
             </section>
         </article>
     )


### PR DESCRIPTION
### Issue ticket(s):  #15 

### New file(s): None

### Modified File(s): Location.js

### Modifications: string interpolated location with dot notation to display employee and animal counts 

### Steps to test:
1. While in the terminal, use git fetch --all in the root directory of this repo
2. Checkout out to hw-animal-user-view
3. Run npm start and click on locations in the nav bar. The counts will be displayed on each card. 
