### PR TITLE
Animals listed in search results are now displayed as links

### DIFF
--- a/src/components/search/SearchResults.js
+++ b/src/components/search/SearchResults.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react"
-import { useLocation } from "react-router-dom";
+import {Link, useLocation } from "react-router-dom";
 import useSimpleAuth from "../../hooks/ui/useSimpleAuth";
+
 import "./SearchResults.css"
 
 
@@ -21,7 +22,7 @@ export default () => {
                     <section className="animals">
                         {
                             location.state?.animals.map(anml => {
-                                return <div key={anml.id}>{anml.name}</div>
+                                return <Link key={anml.id} to={`/animals/${anml.id}`}>{anml.name}</Link>
                             })
                         }
                     </section>


### PR DESCRIPTION
… card for that animal

### Issue ticket(s): #5 and #9

### New file(s): None

### Modified File(s): `SearchResults.js`

### Modifications: Wrapped the `anml.name` in `<Link>` tags in order to take the user to the card for that animal when clicked on!

### Steps to test:
1. While in the terminal, use git fetch --all in the root directory of this repo
2. Checkout out to `al-animalLinksInSearch`
3. Log in to the application as an employee
4. Type in some search criteria in the search bar. (make sure that you include some text from a name of an existing animal in the criteria)
5. All the animals returned in the search results should be displayed as clickable links
6. Once clicked on, you should be routed to a new page that displays the card for the animal you selected! :D
