### PR TITLE
Fixed the employee location and care count bug

### DIFF
--- a/src/components/employees/Employee.js
+++ b/src/components/employees/Employee.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react"
 import { Link, useParams } from "react-router-dom"
 import EmployeeRepository from "../../repositories/EmployeeRepository";
 import LocationRepository from "../../repositories/LocationRepository";
-import AnimalRepository from "../../repositories/AnimalRepository";
 import useResourceResolver from "../../hooks/resource/useResourceResolver";
 import useSimpleAuth from "../../hooks/ui/useSimpleAuth";
 import person from "./person.png"
@@ -10,10 +9,9 @@ import "./Employee.css"
 
 
 export default ({ employee, syncEmployees }) => {
-    const [animalCount, setCount] = useState(0)
     const [location, markLocation] = useState({})
     const [classes, defineClasses] = useState("card employee")
-    const { employeeId, locationId, animalId } = useParams()
+    const { employeeId, locationId } = useParams()
     const { getCurrentUser } = useSimpleAuth()
     const { resolveResource, resource } = useResourceResolver()
     const [isEmployee, setAuth] = useState(false)
@@ -51,23 +49,27 @@ export default ({ employee, syncEmployees }) => {
                                 }}>
                                 {resource.name}
                             </Link>
-
                     }
                 </h5>
                 {
                     employeeId
                         ? <>
                             <section>
-                                Caring for {resource.animals?.length} animals
+                                Caring for {resource.animals?.length} {resource.animals?.length < 2 ? "animal" : "animals"}
                             </section>
                             <section>
                                 Working on unknown treatments
                             </section>
                             <section>
-                                Works at {resource.locations?.map((l) => {
-                                    return <Link className="employee-location"
-                                        to={`/locations/${l.location.id}`}>{l.location.name} </Link>
-                                })}
+                                Works at {
+                                    resource.locations?.length > 0
+                                        ?
+                                        resource.locations?.map((l) => {
+                                            return <Link key={l.id} className="employee-location"
+                                                to={`/locations/${l.location.id}`}>{l.location.name} </Link>
+                                        })
+                                        : "UNASSIGNED"
+                                }
                             </section>
                         </>
                         : ""

--- a/src/components/employees/Employee.js
+++ b/src/components/employees/Employee.js
@@ -61,14 +61,14 @@ export default ({ employee, syncEmployees }) => {
                                 Working on unknown treatments
                             </section>
                             <section>
-                                Works at {
+                                {
                                     resource.locations?.length > 0
                                         ?
                                         resource.locations?.map((l) => {
                                             return <Link key={l.id} className="employee-location"
-                                                to={`/locations/${l.location.id}`}>{l.location.name} </Link>
+                                                to={`/locations/${l.location.id}`}>Works at: {l.location.name} </Link>
                                         })
-                                        : "UNASSIGNED"
+                                        : <div>Works at: <span style={{ color: "red" }}>UNASSIGNED</span></div>
                                 }
                             </section>
                         </>

--- a/src/components/employees/Employee.js
+++ b/src/components/employees/Employee.js
@@ -55,7 +55,7 @@ export default ({ employee, syncEmployees }) => {
                     employeeId
                         ? <>
                             <section>
-                                Caring for {resource.animals?.length} {resource.animals?.length < 2 ? "animal" : "animals"}
+                                Caring for {resource.animals?.length ? resource.animals?.length : 0} {resource.animals?.length < 2 ? "animal" : "animals"}
                             </section>
                             <section>
                                 Working on unknown treatments

--- a/src/components/search/SearchResults.js
+++ b/src/components/search/SearchResults.js
@@ -3,14 +3,11 @@ import {Link, useLocation } from "react-router-dom";
 import useSimpleAuth from "../../hooks/ui/useSimpleAuth";
 
 import "./SearchResults.css"
-import { Link, useParams } from "react-router-dom"
-import LocationRepository from "../../repositories/LocationRepository";
 
 
 
 export default () => {
     const location = useLocation()
-    const { employeeId, locationId, animalId } = useParams()
     const [isEmployee, setAuth] = useState(false)
     const { getCurrentUser } = useSimpleAuth()
 

--- a/src/repositories/EmployeeRepository.js
+++ b/src/repositories/EmployeeRepository.js
@@ -5,18 +5,26 @@ import { fetchIt } from "./Fetch"
 export default {
     async get(id) {
         const userLocations = await fetchIt(`${Settings.remoteURL}/employeeLocations?userId=${id}&_expand=location&_expand=user`)
-        return await fetchIt(`${Settings.remoteURL}/animalCaretakers?userId=${id}&_expand=animal`)
+        return await fetchIt(`${Settings.remoteURL}/animalCaretakers?userId=${id}&_expand=animal&_expand=user`)
             .then(data => {
-                const userWithRelationships = userLocations[0].user
-                userWithRelationships.locations = userLocations
-                userWithRelationships.animals = data
-                return userWithRelationships
+                // debugger
+                if (userLocations.length > 0) {
+                    const userWithRelationships = userLocations[0].user
+                    userWithRelationships.locations = userLocations
+                    userWithRelationships.animals = data
+                    return userWithRelationships
+                }
+                else {
+                    const userWithRelationships = data[0].user
+                    userWithRelationships.animals = data
+                    return userWithRelationships
+                }
             })
     },
     async delete(id) {
         return await fetchIt(`${Settings.remoteURL}/users/${id}`, "DELETE")
     },
-    
+
     async addEmployee(employee) {
         return await fetchIt(`${Settings.remoteURL}/users`, "POST", JSON.stringify(employee))
     },

--- a/src/repositories/EmployeeRepository.js
+++ b/src/repositories/EmployeeRepository.js
@@ -15,12 +15,12 @@ export default {
                     userWithRelationships.animals = userAnimalCare
                     return userWithRelationships
                 }
-                else if (userAnimalCare.length === 0) {
+                else if (userAnimalCare.length === 0 && userLocations.length === 0) {
                     return data
                 }
                 else {
                     const userWithRelationships = userAnimalCare[0].user
-                    userWithRelationships.animals = data
+                    userWithRelationships.animals = userAnimalCare
                     return userWithRelationships
                 }
             })

--- a/src/repositories/EmployeeRepository.js
+++ b/src/repositories/EmployeeRepository.js
@@ -5,17 +5,21 @@ import { fetchIt } from "./Fetch"
 export default {
     async get(id) {
         const userLocations = await fetchIt(`${Settings.remoteURL}/employeeLocations?userId=${id}&_expand=location&_expand=user`)
-        return await fetchIt(`${Settings.remoteURL}/animalCaretakers?userId=${id}&_expand=animal&_expand=user`)
+        const userAnimalCare = await fetchIt(`${Settings.remoteURL}/animalCaretakers?userId=${id}&_expand=animal&_expand=user`)
+        return await fetchIt(`${Settings.remoteURL}/users?employee=true&userId=${id}`)
             .then(data => {
                 // debugger
                 if (userLocations.length > 0) {
                     const userWithRelationships = userLocations[0].user
                     userWithRelationships.locations = userLocations
-                    userWithRelationships.animals = data
+                    userWithRelationships.animals = userAnimalCare
                     return userWithRelationships
                 }
+                else if (userAnimalCare.length === 0) {
+                    return data
+                }
                 else {
-                    const userWithRelationships = data[0].user
+                    const userWithRelationships = userAnimalCare[0].user
                     userWithRelationships.animals = data
                     return userWithRelationships
                 }


### PR DESCRIPTION
### Issue ticket(s): #14 

### New file(s): None

### Modified File(s): `Employee.js`, `EmployeeRepository.js`

### Modifications:
1. `Employee.js`
- Added ternary on line 65 to only display location if the employee selected has corresponding `employeeLocation`object(s)
- Added some conditional logic on line 58 to clean up how that information is displayed to the DOM
2. `EmployeeRepository.js`
- Added a few pieces of conditional logic lines 11-25 with `if else if` statements to filter the way the fetch calls are done dependent upon whether or not the employee has any corresponding `animalCaretaker` and/or `employeeLocation` objects.
### Steps to test:
1. While in the terminal, use git fetch --all in the root directory of this repo
2. Checkout out to `al-cleanupStage`
3. Log in to the application as an employee
4. Navigate the the employee list component
5. Select a few employees and confirm that the correct animal care count and location is being displayed in their information. if they do not have a location assigned to them, the location should read "UNASSIGNED", and if they aren't taking care of any animals, that information should read "0"
