### PR TITLE
employees display when searched

### DIFF
--- a/src/components/search/SearchResults.js
+++ b/src/components/search/SearchResults.js
@@ -41,7 +41,11 @@ export default () => {
                 <React.Fragment>
                     <h2>Matching Employees</h2>
                     <section className="employees">
-                        Display matching employees
+                        {
+                            location.state?.employees.map(emp => {
+                                return <Link key={emp.id} to={`/employees/${emp.id}`}>{emp.name}</Link>
+                            })
+                        }
                     </section>
                 </React.Fragment>
             )


### PR DESCRIPTION
### Issue ticket(s): 
#9 
### New file(s):

### Modified File(s):
`SearchResults.js`
### Modifications:
added code to return employee's names as links when search. The link will take you to the corresponding employee card.
### Steps to test:
1. While in the terminal, use git fetch --all in the root directory of this repo
2. Checkout out to `jm-searchEmps`
3. Login as either employee or non-employee (should work for both)
4. In the search bar at the top of the page, input some letters or search a specific employee name if you know it and hit enter. That should result in displaying any matching employees. 
5. Click on the name of an employee and that should take you to their employee card.